### PR TITLE
feat(api): Add GET /api/articles endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This command will fetch and install the required packages:
 - **Dev Dependencies:**
   - [**`jest`**](https://jestjs.io/)
   - [**`jest-extended`**](https://www.npmjs.com/package/jest-extended)
+  - [**`jest-sorted`**](https://www.npmjs.com/package/jest-sorted)
   - [**`supertest`**](https://www.npmjs.com/package/supertest)
 
 ### 3. Database Setup and Seed Data

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -24,6 +24,94 @@ describe("GET /api", () => {
   });
 });
 
+describe("GET /api/articles", () => {
+  test("200: Returns all articles with the correct format and length", async () => {
+    const response = await request(app).get("/api/articles").expect(200);
+    expect(response.body).toHaveLength(13);
+    expect(Array.isArray(response.body)).toBe(true);
+    response.body.forEach((article) => {
+      expect(article).toHaveProperty("author");
+      expect(article.author).toEqual(expect.any(String))
+      expect(article).toHaveProperty("title");
+      expect(article.title).toEqual(expect.any(String))
+      expect(article).toHaveProperty("article_id");
+      expect(article.article_id).toEqual(expect.any(Number))
+      expect(article).toHaveProperty("topic");
+      expect(article.topic).toEqual(expect.any(String))
+      expect(article).toHaveProperty("created_at");
+      expect(article.created_at).toEqual(expect.any(String))
+      expect(article).toHaveProperty("votes");
+      expect(article.votes).toEqual(expect.any(Number))
+      expect(article).toHaveProperty("article_img_url");
+      expect(article.article_img_url).toEqual(expect.any(String))
+      expect(article).not.toHaveProperty("body");
+      expect(article).toHaveProperty("comment_count");
+      expect(article.comment_count).toEqual(expect.any(Number))
+    });
+  });
+  test("200: Returns articles sorted by date in descending order", async () => {
+    const response = await request(app).get("/api/articles").expect(200);
+    expect(response.body).toBeSortedBy("created_at", { descending: true });
+  });
+  
+  test("200: Returns expected article data", async () => {
+    const response = await request(app).get("/api/articles").expect(200);
+    expect(response.body[0]).toEqual({
+      article_id: 3,
+      article_img_url:
+        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+      author: "icellusedkars",
+      comment_count: 2,
+      created_at: "2020-11-03T09:12:00.000Z",
+      title: "Eight pug gifs that remind me of mitch",
+      topic: "mitch",
+      votes: 0,
+    });
+
+    expect(response.body[12]).toEqual({
+      article_id: 7,
+      article_img_url:
+        "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+      author: "icellusedkars",
+      comment_count: 0,
+      created_at: "2020-01-07T14:08:00.000Z",
+      title: "Z",
+      topic: "mitch",
+      votes: 0,
+    });
+  });
+
+
+  test("500: Internal Server Error", async () => {
+    const mockQuery = jest
+      .spyOn(db, "query")
+      .mockRejectedValueOnce(new Error("Database error"));
+    const response = await request(app).get("/api/articles").expect(500);
+    expect(response.body.msg).toBe("Internal Server Error");
+    mockQuery.mockRestore();
+  });
+
+  test("400: Bad request, invalid sort_by", async () => {
+    const response = await request(app)
+      .get("/api/articles?sort_by=invalid")
+      .expect(400);
+    expect(response.body.msg).toBe("Invalid sort_by value: invalid");
+  });
+  test("400: Bad request, invalid order", async () => {
+    const response = await request(app)
+      .get("/api/articles?order=invalid")
+      .expect(400);
+    expect(response.body.msg).toBe("Invalid order value: invalid");
+  });
+
+  test("400: Bad request, invalid order and sort_by", async () => {
+    const response = await request(app)
+      .get("/api/articles?order=invalid&sort_by=invalid")
+      .expect(400);
+    expect(response.body.msg).toBe("Invalid sort_by and order values");
+  });
+});
+
 describe("GET /api/topics", () => {
   test("200: Return all topics", async () => {
     const response = await request(app).get("/api/topics").expect(200);

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const app = express();
 
 app.get("/api", api.getEndpoints);
 app.get("/api/topics", topics.getTopics);
+app.get("/api/articles", articles.getArticles);
 app.get("/api/articles/:article_id", articles.getArticle);
 errorHandler(app);
 

--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -1,10 +1,20 @@
-const { fetchArticle } = require("../models/articles");
+const { fetchArticle, fetchArticles } = require("../models/articles");
 
 exports.getArticle = async (req, res, next) => {
   const { article_id } = req.params;
   try {
     const article = await fetchArticle(article_id);
     res.status(200).send(article);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getArticles = async (req, res, next) => {
+  const { sort_by, order } = req.query;
+  try {
+    const articles = await fetchArticles(sort_by, order);
+    res.status(200).send(articles);
   } catch (err) {
     next(err);
   }

--- a/endpoints.json
+++ b/endpoints.json
@@ -27,18 +27,39 @@
     },
     "/api/articles": {
       "method": "GET",
-      "description": "Returns an array of all articles",
-      "queries": ["author", "topic", "sort_by", "order"],
+      "description": "Returns an array of all articles, sorted by default in descending order by created_at",
+      "queries": ["sort_by, order"],
       "requestBody": null,
       "exampleResponse": {
         "articles": [
           {
-            "title": "Seafood substitutions are increasing",
-            "topic": "cooking",
             "author": "weegembump",
-            "body": "Text from the article..",
-            "created_at": "2018-05-30T15:59:13.341Z",
+            "title": "The best fish for the week",
+            "article_id": 3,
+            "topic": "cooking",
+            "created_at": "2022-05-30T15:59:13.341Z",
             "votes": 0,
+            "article_img_url": "https://example.com/best-fish-for-the-week.jpg",
+            "comment_count": 5
+          },
+          {
+            "author": "weegembump",
+            "title": "The Great Seafood Debate",
+            "article_id": 2,
+            "topic": "cooking",
+            "created_at": "2021-05-30T15:59:13.341Z",
+            "votes": 0,
+            "article_img_url": "https://example.com/great-seafood-debate.jpg",
+            "comment_count": 10
+          },
+          {
+            "author": "weegembump",
+            "title": "Seafood substitutions are increasing",
+            "article_id": 1,
+            "topic": "cooking",
+            "created_at": "2020-05-29T15:59:13.341Z",
+            "votes": 0,
+            "article_img_url": "https://example.com/seafood-article.jpg",
             "comment_count": 6
           }
         ]

--- a/models/articles.js
+++ b/models/articles.js
@@ -5,7 +5,49 @@ exports.fetchArticle = async (article_id) => {
   } = await db.query(`SELECT * FROM articles WHERE article_id=$1`, [
     article_id,
   ]);
-  return article
-  ? article
-  : Promise.reject({ status: 404, msg: "Article not found" });
+  return article || Promise.reject({ status: 404, msg: "Article not found" });
+};
+
+exports.fetchArticles = async (sort_by = "created_at", order = "desc") => {
+  const validSortBy = ["created_at", "author", "title", "topic", "votes"];
+  const validOrder = ["asc", "desc"];
+
+  if (!validSortBy.includes(sort_by) && !validOrder.includes(order)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = "Invalid sort_by and order values";
+    throw err;
+  }
+
+  if (!validSortBy.includes(sort_by)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = `Invalid sort_by value: ${sort_by}`;
+    throw err;
+  }
+
+  if (!validOrder.includes(order)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = `Invalid order value: ${order}`;
+    throw err;
+  }
+
+  const query = `
+    SELECT 
+      articles.article_id, 
+      articles.author, 
+      articles.title, 
+      articles.topic, 
+      articles.created_at, 
+      articles.votes, 
+      articles.article_img_url, 
+      CAST(COUNT(comments.article_id) AS INTEGER) AS comment_count
+    FROM articles
+    LEFT JOIN comments ON articles.article_id = comments.article_id
+    GROUP BY articles.article_id
+    ORDER BY ${sort_by} ${order}`;
+
+  const { rows: articles } = await db.query(query);
+  return articles;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4"
       }
     },
@@ -3221,6 +3222,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "node_modules/jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4"
   },
   "dependencies": {
@@ -34,7 +35,7 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all", "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Endpoint retrieves all articles.
Responds with an array of article objects containing the following properties:
  - author
  - title
  - article_id
  - topic
  - created_at
  - votes
  - article_img_url
  - comment_count (calculated as the total count of comments with this article_id) Articles are sorted by created_at in descending order by default. Added query parameters for sort_by and order.
Exclude the body property from article objects in the response. Handle 404, 400, and 500 errors and add corresponding tests. Update /api endpoint JSON file with the description of GET /api/articles endpoint.