### PR TITLE
06 feature get article comments endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -30,23 +30,17 @@ describe("GET /api/articles", () => {
     expect(response.body).toHaveLength(13);
     expect(Array.isArray(response.body)).toBe(true);
     response.body.forEach((article) => {
-      expect(article).toHaveProperty("author");
-      expect(article.author).toEqual(expect.any(String))
-      expect(article).toHaveProperty("title");
-      expect(article.title).toEqual(expect.any(String))
-      expect(article).toHaveProperty("article_id");
-      expect(article.article_id).toEqual(expect.any(Number))
-      expect(article).toHaveProperty("topic");
-      expect(article.topic).toEqual(expect.any(String))
-      expect(article).toHaveProperty("created_at");
-      expect(article.created_at).toEqual(expect.any(String))
-      expect(article).toHaveProperty("votes");
-      expect(article.votes).toEqual(expect.any(Number))
-      expect(article).toHaveProperty("article_img_url");
-      expect(article.article_img_url).toEqual(expect.any(String))
+      expect(article).toMatchObject({
+        article_id: expect.any(Number),
+        author: expect.any(String),
+        title: expect.any(String),
+        topic: expect.any(String),
+        created_at: expect.any(String),
+        votes: expect.any(Number),
+        article_img_url: expect.any(String),
+        comment_count: expect.any(Number),
+      });
       expect(article).not.toHaveProperty("body");
-      expect(article).toHaveProperty("comment_count");
-      expect(article.comment_count).toEqual(expect.any(Number))
     });
   });
   test("200: Returns articles sorted by date in descending order", async () => {

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ app.get("/api", api.getEndpoints);
 app.get("/api/topics", topics.getTopics);
 app.get("/api/articles", articles.getArticles);
 app.get("/api/articles/:article_id", articles.getArticle);
+app.get("/api/articles/:article_id/comments", articles.getComments);
 errorHandler(app);
 
 module.exports = app;

--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -1,4 +1,8 @@
-const { fetchArticle, fetchArticles } = require("../models/articles");
+const {
+  fetchArticle,
+  fetchArticles,
+  fetchComments,
+} = require("../models/articles");
 
 exports.getArticle = async (req, res, next) => {
   const { article_id } = req.params;
@@ -15,6 +19,16 @@ exports.getArticles = async (req, res, next) => {
   try {
     const articles = await fetchArticles(sort_by, order);
     res.status(200).send(articles);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.getComments = async (req, res, next) => {
+  const { article_id } = req.params;
+  try {
+    const comments = await fetchComments(article_id);
+    res.status(200).send(comments);
   } catch (err) {
     next(err);
   }

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -20,3 +20,29 @@ exports.formatComments = (comments, idLookup) => {
     };
   });
 };
+
+exports.validateSortAndOrder = (sort_by, order) => {
+  const validSortBy = ["created_at", "author", "title", "topic", "votes"];
+  const validOrder = ["asc", "desc"];
+
+  if (!validSortBy.includes(sort_by) && !validOrder.includes(order)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = "Invalid sort_by and order values";
+    throw err;
+  }
+
+  if (!validSortBy.includes(sort_by)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = `Invalid sort_by value: ${sort_by}`;
+    throw err;
+  }
+
+  if (!validOrder.includes(order)) {
+    const err = new Error();
+    err.status = 400;
+    err.msg = `Invalid order value: ${order}`;
+    throw err;
+  }
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -9,7 +9,8 @@
         "endpoints": {
           "/api/topics": {},
           "/api/articles": {},
-          "/api/articles/:article_id": {}
+          "/api/articles/:article_id": {},
+          "/api/articles/:article_id/comments": {}
         }
       }
     },
@@ -81,6 +82,32 @@
           "comment_count": 6,
           "article_img_url": "https://example.com/seafood-article.jpg"
         }
+      }
+    },
+    "/api/articles/:article_id/comments": {
+      "method": "GET",
+      "description": "Returns an array of all comments for an article, sorted by default in descending order by created_at",
+      "queries": ["sort_by, order"],
+      "requestBody": null,
+      "exampleResponse": {
+        "comments": [
+          {
+            "comment_id": 1,
+            "votes": 0,
+            "created_at": "2022-05-30T15:59:13.341Z",
+            "author": "weegembump",
+            "body": "A comment...",
+            "article_id": 3
+          },
+          {
+            "comment_id": 2,
+            "votes": 0,
+            "created_at": "2021-05-30T15:59:13.341Z",
+            "author": "weegembump",
+            "body": "Another comment...",
+            "article_id": 3
+          }
+        ]
       }
     }
   }

--- a/models/articles.js
+++ b/models/articles.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const utils = require("../db/seeds/utils");
 exports.fetchArticle = async (article_id) => {
   const {
     rows: [article],
@@ -9,29 +10,7 @@ exports.fetchArticle = async (article_id) => {
 };
 
 exports.fetchArticles = async (sort_by = "created_at", order = "desc") => {
-  const validSortBy = ["created_at", "author", "title", "topic", "votes"];
-  const validOrder = ["asc", "desc"];
-
-  if (!validSortBy.includes(sort_by) && !validOrder.includes(order)) {
-    const err = new Error();
-    err.status = 400;
-    err.msg = "Invalid sort_by and order values";
-    throw err;
-  }
-
-  if (!validSortBy.includes(sort_by)) {
-    const err = new Error();
-    err.status = 400;
-    err.msg = `Invalid sort_by value: ${sort_by}`;
-    throw err;
-  }
-
-  if (!validOrder.includes(order)) {
-    const err = new Error();
-    err.status = 400;
-    err.msg = `Invalid order value: ${order}`;
-    throw err;
-  }
+  utils.validateSortAndOrder(sort_by, order);
 
   const query = `
     SELECT 

--- a/models/articles.js
+++ b/models/articles.js
@@ -30,3 +30,40 @@ exports.fetchArticles = async (sort_by = "created_at", order = "desc") => {
   const { rows: articles } = await db.query(query);
   return articles;
 };
+
+exports.fetchComments = async (
+  article_id,
+  sort_by = "created_at",
+  order = "desc",
+) => {
+  utils.validateSortAndOrder(sort_by, order);
+  const query = `
+    SELECT 
+      comments.comment_id, 
+      comments.votes, 
+      comments.created_at, 
+      comments.author, 
+      comments.body, 
+      comments.article_id
+    FROM comments
+    WHERE article_id = $1 
+    ORDER BY ${sort_by} ${order}`;
+  try {
+    const { rows: comments } = await db.query(query, [article_id]);
+    if (comments.length === 0) {
+      return Promise.reject({ status: 404, msg: "Article not found" });
+    }
+    return comments.map((comment) => {
+      return {
+        comment_id: comment.comment_id,
+        votes: comment.votes,
+        created_at: comment.created_at,
+        author: comment.author,
+        body: comment.body,
+        article_id: comment.article_id,
+      };
+    });
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};


### PR DESCRIPTION
feat(api): Add GET /api/articles/:article_id/comments endpoint

Responds with an array of comment objects for the provided article_id containing the following properties:
comment_id
  - votes
  - created_at
  - author
  - body
  - article_id
Articles are sorted by created_at in descending order by default.
Added query parameters for sort_by and order.
Handle 404, 400, and 500 errors and add corresponding tests.
Update /api endpoint JSON file with the description of GET /api/articles/:article_id/comments endpoint.