### PR TITLE
feat(api): Add POST /api/articles/:article_id/comments endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -257,3 +257,53 @@ describe("GET /api/articles/:article_id/comments", () => {
     });
   });
 });
+
+describe("POST /api/articles/:article_id/comments", () => {
+  const validComment = {
+    username: "butter_bridge",
+    body: "This is a test comment",
+  };
+
+  test("201: Should create a new comment with the provided username and body", async () => {
+    const response = await request(app)
+      .post("/api/articles/1/comments")
+      .send(validComment)
+      .expect(201);
+
+    expect(response.body).toEqual({
+      article_id: 1,
+      author: "butter_bridge",
+      body: "This is a test comment",
+    });
+  });
+
+  test("400: Bad request, invalid article_id", async () => {
+    const response = await request(app)
+      .post("/api/articles/invalid/comments")
+      .send(validComment)
+      .expect(400);
+
+    expect(response.body.msg).toBe("Bad request");
+  });
+
+  test("400: Row not found, article_id does not exist", async () => {
+    const response = await request(app)
+      .post("/api/articles/999/comments")
+      .send(validComment)
+      .expect(400);
+
+    expect(response.body.msg).toBe("Row not found");
+  });
+
+  test("400: Invalid request, missing username", async () => {
+    const invalidComment = {
+      body: "This is a test comment",
+    };
+    const response = await request(app)
+      .post("/api/articles/1/comments")
+      .send(invalidComment)
+      .expect(400);
+
+    expect(response.body.msg).toBe("Invalid request");
+  });
+});

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const {
   api,
 } = require("./controllers/index");
 const app = express();
+app.use(express.json());
 
 app.get("/api", api.getEndpoints);
 app.get("/api/topics", topics.getTopics);
@@ -15,6 +16,8 @@ app.get("/api/articles", articles.getArticles);
 app.get("/api/articles/:article_id", articles.getArticle);
 
 app.get("/api/articles/:article_id/comments", comments.getComments);
+app.post("/api/articles/:article_id/comments", comments.postComment);
+
 errorHandler(app);
 
 module.exports = app;

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,13 +1,22 @@
-const {
-    fetchComments,
-  } = require("../models/comments");
+const { fetchComments, addComment } = require("../models/comments");
 
 exports.getComments = async (req, res, next) => {
-    const { article_id } = req.params;
-    try {
-      const comments = await fetchComments(article_id);
-      res.status(200).send(comments);
-    } catch (err) {
-      next(err);
-    }
-  };
+  const { article_id } = req.params;
+  try {
+    const comments = await fetchComments(article_id);
+    res.status(200).send(comments);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.postComment = async (req, res, next) => {
+  const { article_id } = req.params;
+  const { username, body } = req.body;
+  try {
+    const comment = await addComment(article_id, username, body);
+    res.status(201).send(comment);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -84,31 +84,49 @@
         }
       }
     },
-    "/api/articles/:article_id/comments": {
-      "method": "GET",
-      "description": "Returns an array of all comments for an article, sorted by default in descending order by created_at",
-      "queries": ["sort_by, order"],
-      "requestBody": null,
-      "exampleResponse": {
-        "comments": [
-          {
-            "comment_id": 1,
-            "votes": 0,
-            "created_at": "2022-05-30T15:59:13.341Z",
-            "author": "weegembump",
-            "body": "A comment...",
-            "article_id": 3
-          },
-          {
-            "comment_id": 2,
-            "votes": 0,
-            "created_at": "2021-05-30T15:59:13.341Z",
-            "author": "weegembump",
-            "body": "Another comment...",
-            "article_id": 3
+    "/api/articles/:article_id/comments": [
+      {
+        "method": "GET",
+        "description": "Returns an array of all comments for an article, sorted by default in descending order by created_at",
+        "queries": ["sort_by", "order"],
+        "requestBody": null,
+        "exampleResponse": {
+          "comments": [
+            {
+              "comment_id": 1,
+              "votes": 0,
+              "created_at": "2022-05-30T15:59:13.341Z",
+              "author": "weegembump",
+              "body": "A comment...",
+              "article_id": 3
+            },
+            {
+              "comment_id": 2,
+              "votes": 0,
+              "created_at": "2021-05-30T15:59:13.341Z",
+              "author": "weegembump",
+              "body": "Another comment...",
+              "article_id": 3
+            }
+          ]
+        }
+      },
+      {
+        "method": "POST",
+        "description": "Adds a comment to an article. Request body should have 'username' and 'body' properties",
+        "queries": [],
+        "requestBody": {
+          "username": "string",
+          "body": "string"
+        },
+        "exampleResponse": {
+          "comment": {
+            "article_id": 3,
+            "author": "username",
+            "body": "A comment..."
           }
-        ]
+        }
       }
-    }
+    ]
   }
 }

--- a/models/comments.js
+++ b/models/comments.js
@@ -2,12 +2,12 @@ const db = require("../db/connection");
 const utils = require("../db/seeds/utils");
 
 exports.fetchComments = async (
-    article_id,
-    sort_by = "created_at",
-    order = "desc",
-  ) => {
-    utils.validateSortAndOrder(sort_by, order);
-    const query = `
+  article_id,
+  sort_by = "created_at",
+  order = "desc",
+) => {
+  utils.validateSortAndOrder(sort_by, order);
+  const query = `
       SELECT 
         comments.comment_id, 
         comments.votes, 
@@ -18,22 +18,32 @@ exports.fetchComments = async (
       FROM comments
       WHERE article_id = $1 
       ORDER BY ${sort_by} ${order}`;
-    try {
-      const { rows: comments } = await db.query(query, [article_id]);
-      if (comments.length === 0) {
-        return Promise.reject({ status: 404, msg: "Article not found" });
-      }
-      return comments.map((comment) => {
-        return {
-          comment_id: comment.comment_id,
-          votes: comment.votes,
-          created_at: comment.created_at,
-          author: comment.author,
-          body: comment.body,
-          article_id: comment.article_id,
-        };
-      });
-    } catch (err) {
-      return Promise.reject(err);
+  try {
+    const { rows: comments } = await db.query(query, [article_id]);
+    if (comments.length === 0) {
+      return Promise.reject({ status: 404, msg: "Article not found" });
     }
-  };
+    return comments.map((comment) => {
+      return {
+        comment_id: comment.comment_id,
+        votes: comment.votes,
+        created_at: comment.created_at,
+        author: comment.author,
+        body: comment.body,
+        article_id: comment.article_id,
+      };
+    });
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};
+
+exports.addComment = async (article_id, username, body) => {
+  const query = ` INSERT INTO comments (article_id, author, body) VALUES ($1, $2, $3) RETURNING author, body, article_id`;
+  try {
+    const comment = await db.query(query, [article_id, username, body]);
+    return comment.rows[0];
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};


### PR DESCRIPTION
This endpoint enable a post request to add a comment to an article. Request body accepts an object with 'username' and 'body' properties. Responds with the posted comment.
Handle 400, and 500 errors and add corresponding tests. Update the /api endpoint JSON file with the description of POST /api/articles/:article_id/comments endpoint.