### PR TITLE
feat(api): Implement PATCH /api/articles/:article_id endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ app.get("/api", api.getEndpoints);
 app.get("/api/topics", topics.getTopics);
 app.get("/api/articles", articles.getArticles);
 app.get("/api/articles/:article_id", articles.getArticle);
+app.patch("/api/articles/:article_id", articles.patchArticle);
 
 app.get("/api/articles/:article_id/comments", comments.getComments);
 app.post("/api/articles/:article_id/comments", comments.postComment);

--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -1,6 +1,7 @@
 const {
   fetchArticle,
   fetchArticles,
+  updateArticle,
 } = require("../models/articles");
 
 exports.getArticle = async (req, res, next) => {
@@ -18,6 +19,17 @@ exports.getArticles = async (req, res, next) => {
   try {
     const articles = await fetchArticles(sort_by, order);
     res.status(200).send(articles);
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.patchArticle = async (req, res, next) => {
+  const { article_id } = req.params;
+  const { inc_votes } = req.body;
+  try {
+    const article = await updateArticle(article_id, inc_votes);
+    res.status(200).send(article);
   } catch (err) {
     next(err);
   }

--- a/endpoints.json
+++ b/endpoints.json
@@ -128,5 +128,24 @@
         }
       }
     ]
+  },
+  "/api/articles/:article_id": {
+    "method": "PATCH",
+    "description": "Updates an article by article_id. Request body accepts: { inc_votes: newVote }. newVote will indicate how much the votes property in the database should be updated by.",
+    "queries": [],
+    "requestBody": {
+      "inc_votes": 1
+    },
+    "exampleResponse": {
+      "article": {
+        "author": "weegembump",
+        "title": "Seafood substitutions are increasing",
+        "topic": "cooking",
+        "created_at": "2020-05-29T15:59:13.341Z",
+        "votes": 6,
+        "comment_count": 6,
+        "article_img_url": "https://example.com/seafood-article.jpg"
+      }
+    }
   }
 }

--- a/models/articles.js
+++ b/models/articles.js
@@ -30,3 +30,11 @@ exports.fetchArticles = async (sort_by = "created_at", order = "desc") => {
   const { rows: articles } = await db.query(query);
   return articles;
 };
+
+exports.updateArticle = async (article_id, inc_votes) => {
+  const { rows: [article] } = await db.query(
+    `UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`,
+    [inc_votes, article_id],
+  );
+  return article || Promise.reject({ status: 404, msg: "Article not found" });
+};


### PR DESCRIPTION
This endpoint allows updating an article by article_id.
The request body accepts an object in the form { inc_votes: newVote }, where newVote indicates the amount by which to update the article's votes property. Responds with the updated article.
Handle 400, 404 and 500 errors, and add corresponding tests.
The /api endpoint JSON file has been updated with the description of the PATCH /api/articles/:article_id endpoint.