### PR TITLE
feat(api): Implement DELETE /api/comments/:comment_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -377,3 +377,38 @@ describe("PATCH /api/articles/:articleId", () => {
     mockQuery.mockRestore();
   });
 });
+
+describe('DELETE /api/comments/:comment_id', () => {
+
+  test('204: Should delete a comment by comment_id', async () => {
+    const response = await request(app)
+      .delete('/api/comments/1')
+      .expect(204);
+    expect(response.body).toEqual({});
+  });
+
+  test('400: Bad request, invalid comment_id', async () => {
+    const response = await request(app)
+      .delete('/api/comments/invalid')
+      .expect(400);
+    expect(response.body.msg).toBe('Bad request');
+  });
+
+  test('404: Not found, comment_id does not exist', async () => {
+    const response = await request(app)
+      .delete('/api/comments/1337')
+      .expect(404);
+    expect(response.body.msg).toBe('Comment not found');
+  });
+
+  test('500: Internal Server Error', async () => {
+    const mockQuery = jest
+      .spyOn(db, 'query')
+      .mockRejectedValueOnce(new Error('Database error'));
+    const response = await request(app)
+      .delete('/api/comments/1')
+      .expect(500);
+    expect(response.body.msg).toBe('Internal Server Error');
+    mockQuery.mockRestore();
+  }); 
+});

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ app.patch("/api/articles/:article_id", articles.patchArticle);
 
 app.get("/api/articles/:article_id/comments", comments.getComments);
 app.post("/api/articles/:article_id/comments", comments.postComment);
+app.delete("/api/comments/:comment_id", comments.deleteComment);
 
 errorHandler(app);
 

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,4 +1,4 @@
-const { fetchComments, addComment } = require("../models/comments");
+const { fetchComments, addComment, removeComment } = require("../models/comments");
 
 exports.getComments = async (req, res, next) => {
   const { article_id } = req.params;
@@ -18,5 +18,15 @@ exports.postComment = async (req, res, next) => {
     res.status(201).send(comment);
   } catch (err) {
     next(err);
+  }
+};
+
+exports.deleteComment = async (req, res, next) => {
+  const { comment_id } = req.params;
+  try {
+    await removeComment(comment_id);
+    res.sendStatus(204);
+  } catch (error) {
+    next(error);
   }
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,7 +10,8 @@
           "/api/topics": {},
           "/api/articles": {},
           "/api/articles/:article_id": {},
-          "/api/articles/:article_id/comments": {}
+          "/api/articles/:article_id/comments": {},
+          "/api/comments/:comment_id": {}
         }
       }
     },
@@ -127,7 +128,14 @@
           }
         }
       }
-    ]
+    ],
+    "/api/comments/:comment_id": {
+      "method": "DELETE",
+      "description": "Deletes a comment by comment ID. Responds with status 204 and no content.",
+      "queries": [],
+      "requestBody": null,
+      "exampleResponse": null
+    }
   },
   "/api/articles/:article_id": {
     "method": "PATCH",

--- a/models/comments.js
+++ b/models/comments.js
@@ -47,3 +47,19 @@ exports.addComment = async (article_id, username, body) => {
     return Promise.reject(err);
   }
 };
+
+exports.removeComment = async (comment_id) => {
+  const query = `DELETE FROM comments WHERE comment_id = $1`;
+  try {
+    const comment = await db.query(
+      "SELECT * FROM comments WHERE comment_id = $1",
+      [comment_id],
+    );
+    if (comment.rows.length === 0) {
+      return Promise.reject({ status: 404, msg: "Comment not found" });
+    }
+    await db.query(query, [comment_id]);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};


### PR DESCRIPTION
This endpoint allows deleting a comment by comment_id. Responds with status 204 and no content.
Handle 400, 404 and 500 errors, and add corresponding tests. The /api endpoint JSON file has been updated with the description of DELETE /api/comments/:comment_id endpoint.