### PR TITLE
feat(api): Implement GET /api/users endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -378,37 +378,53 @@ describe("PATCH /api/articles/:articleId", () => {
   });
 });
 
-describe('DELETE /api/comments/:comment_id', () => {
-
-  test('204: Should delete a comment by comment_id', async () => {
-    const response = await request(app)
-      .delete('/api/comments/1')
-      .expect(204);
+describe("DELETE /api/comments/:comment_id", () => {
+  test("204: Should delete a comment by comment_id", async () => {
+    const response = await request(app).delete("/api/comments/1").expect(204);
     expect(response.body).toEqual({});
   });
 
-  test('400: Bad request, invalid comment_id', async () => {
+  test("400: Bad request, invalid comment_id", async () => {
     const response = await request(app)
-      .delete('/api/comments/invalid')
+      .delete("/api/comments/invalid")
       .expect(400);
-    expect(response.body.msg).toBe('Bad request');
+    expect(response.body.msg).toBe("Bad request");
   });
 
-  test('404: Not found, comment_id does not exist', async () => {
+  test("404: Not found, comment_id does not exist", async () => {
     const response = await request(app)
-      .delete('/api/comments/1337')
+      .delete("/api/comments/1337")
       .expect(404);
-    expect(response.body.msg).toBe('Comment not found');
+    expect(response.body.msg).toBe("Comment not found");
   });
 
-  test('500: Internal Server Error', async () => {
+  test("500: Internal Server Error", async () => {
     const mockQuery = jest
-      .spyOn(db, 'query')
-      .mockRejectedValueOnce(new Error('Database error'));
-    const response = await request(app)
-      .delete('/api/comments/1')
-      .expect(500);
-    expect(response.body.msg).toBe('Internal Server Error');
+      .spyOn(db, "query")
+      .mockRejectedValueOnce(new Error("Database error"));
+    const response = await request(app).delete("/api/comments/1").expect(500);
+    expect(response.body.msg).toBe("Internal Server Error");
     mockQuery.mockRestore();
-  }); 
+  });
+});
+
+describe("GET /api/users", () => {
+  const expectedUsers = data.userData;
+
+  test("200: Return all users", async () => {
+    const { body: users } = await request(app).get("/api/users").expect(200);
+    expect(users).toHaveLength(expectedUsers.length);
+    users.forEach((user, index) => {
+      expect(user).toMatchObject(expectedUsers[index]);
+    });
+  });
+
+  test("500: Internal Server Error", async () => {
+    const mockQuery = jest
+      .spyOn(db, "query")
+      .mockRejectedValueOnce(new Error("Database error"));
+    const response = await request(app).get("/api/users").expect(500);
+    expect(response.body.msg).toBe("Internal Server Error");
+    mockQuery.mockRestore();
+  });
 });

--- a/app.js
+++ b/app.js
@@ -20,6 +20,8 @@ app.get("/api/articles/:article_id/comments", comments.getComments);
 app.post("/api/articles/:article_id/comments", comments.postComment);
 app.delete("/api/comments/:comment_id", comments.deleteComment);
 
+app.get("/api/users", users.getUsers);
+
 errorHandler(app);
 
 module.exports = app;

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -1,0 +1,10 @@
+const { getUsers } = require("../models/users");
+
+exports.getUsers = async (req, res, next) => {
+  try {
+    const users = await getUsers();
+    res.status(200).send(users);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -7,11 +7,12 @@
       "requestBody": null,
       "exampleResponse": {
         "endpoints": {
-          "/api/topics": {},
-          "/api/articles": {},
+          "/api/topics": [{}, {}, {}, {}],
+          "/api/articles": [{}, {}, {}, {}],
           "/api/articles/:article_id": {},
-          "/api/articles/:article_id/comments": {},
-          "/api/comments/:comment_id": {}
+          "/api/articles/:article_id/comments": [{}, {}, {}, {}],
+          "/api/comments/:comment_id": {},
+          "/api/users": [{}, {}, {}, {}]
         }
       }
     },
@@ -155,5 +156,33 @@
         "article_img_url": "https://example.com/seafood-article.jpg"
       }
     }
+  },
+  "/api/users": {
+    "method": "GET",
+    "description": "Returns an array of all users containing the properties username, name, and avatar_url. Handles potential errors and is documented in the /api endpoint.",
+    "queries": [],
+    "requestBody": null,
+    "exampleResponse": [
+      {
+        "username": "string",
+        "name": "string",
+        "avatar_url": "string"
+      },
+      {
+        "username": "string",
+        "name": "string",
+        "avatar_url": "string"
+      },
+      {
+        "username": "string",
+        "name": "string",
+        "avatar_url": "string"
+      },
+      {
+        "username": "string",
+        "name": "string",
+        "avatar_url": "string"
+      }
+    ]
   }
 }

--- a/models/users.js
+++ b/models/users.js
@@ -1,0 +1,10 @@
+const db = require("../db/connection");
+
+exports.getUsers = async () => {
+  try {
+    const { rows: users } = await db.query("SELECT * FROM users");
+    return users;
+  } catch (err) {
+    return Promise.reject(err);
+  }
+};


### PR DESCRIPTION
This endpoint allows retrieving all users.
Responds with an array of user objects, each containing the following properties:
- username
- name
- avatar_url Handle 500 errors, and add corresponding tests.
The /api endpoint JSON file has been updated with the description of GET /api/users endpoint.